### PR TITLE
Enforce OO conventions

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -8,7 +8,7 @@ import decimal
 
 class Policy():
     """A Generic policy class."""
-    def validate():
+    def validate(self):
         """A validator of the data held by the object."""
         pass
 


### PR DESCRIPTION
Classes methods should use self as first argument of methods,
even when not used, and even for abstract classes.