### PR TITLE
Avoid parentheses after class declaration

### DIFF
--- a/importers/smals/__init__.py
+++ b/importers/smals/__init__.py
@@ -20,7 +20,7 @@ from beancount.ingest import regression
 
 from utils.utils import toAmount
 
-class TimesheetCsvFileDefinition():
+class TimesheetCsvFileDefinition:
     """A class that define the input file and provides all the facilities to read it."""
     def __init__(self, logger):
         self.logger = logger

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -6,7 +6,7 @@ from beancount.core import amount
 from enum import Enum, IntEnum, unique, auto
 import decimal
 
-class Policy():
+class Policy:
     """A Generic policy class."""
     def validate():
         """A validator of the data held by the object."""


### PR DESCRIPTION
The parentheses are here redundant.