### PR TITLE
Adhere more to PEP-8 convention

### DIFF
--- a/importers/smals/__init__.py
+++ b/importers/smals/__init__.py
@@ -20,8 +20,10 @@ from beancount.ingest import regression
 
 from utils.utils import toAmount
 
+
 class TimesheetCsvFileDefinition():
     """A class that define the input file and provides all the facilities to read it."""
+
     def __init__(self, logger):
         self.logger = logger
 
@@ -57,7 +59,8 @@ class TimesheetCsvFileDefinition():
 
         self.logger.debug("Filename to analyse %s", filename)
 
-        matching_result = re.match(r"{}{}{}".format(self.core_filename_regex, self.tag_suffix_regex, self.extension_regex), path.basename(filename))
+        matching_result = re.match(r"{}{}{}".format(
+            self.core_filename_regex, self.tag_suffix_regex, self.extension_regex), path.basename(filename))
 
         self.logger.debug("Leaving Function")
 
@@ -75,6 +78,7 @@ class TimesheetCsvFileDefinition():
         self.logger.debug("Leaving Function")
 
         return dateinfile
+
 
 class Importer(importer.ImporterProtocol):
     """An importer for the Timesheet Report CSV files provided by one of my customer."""
@@ -95,7 +99,8 @@ class Importer(importer.ImporterProtocol):
         self.logger = logging.Logger("smals", logging.DEBUG)
 
         fh = logging.FileHandler('smals-importer.log')
-        fmtr = logging.Formatter('%(asctime)s - %(levelname)s - %(lineno)d - %(funcName)s | %(message)s')
+        fmtr = logging.Formatter(
+            '%(asctime)s - %(levelname)s - %(lineno)d - %(funcName)s | %(message)s')
 
         fh.setFormatter(fmtr)
         self.logger.addHandler(fh)
@@ -103,7 +108,8 @@ class Importer(importer.ImporterProtocol):
         self.commodity_overtime = commodity_overtime
         self.commodity_vacation_day = commodity_vacation_day
         self.commodity_workday = commodity_workday
-        self.standard_work_period = self.__str_time_to_minutes(standard_work_period)
+        self.standard_work_period = self.__str_time_to_minutes(
+            standard_work_period)
         self.employer = employer
         self.customer = customer
         self.account_working_day = account_working_day
@@ -115,46 +121,63 @@ class Importer(importer.ImporterProtocol):
         self.account_employer_worked_day = account_employer_worked_day
         self.account_sickness = account_sickness
         self.account_vacation = account_vacation
-        
+
         self.inputFile = TimesheetCsvFileDefinition(self.logger)
-        
+
         self.logger.info("Logger Initialized")
         self.logger.debug("Input parameters:")
-        self.logger.debug("Commodity name for overtime units: %s", self.commodity_overtime)
-        self.logger.debug("Commodity name for vacation day units: %s", self.commodity_vacation_day)
-        self.logger.debug("Commodity name for worked day units: %s", self.commodity_workday)
-        self.logger.debug("Standard work time period: %s", str(self.standard_work_period))
+        self.logger.debug(
+            "Commodity name for overtime units: %s", self.commodity_overtime)
+        self.logger.debug(
+            "Commodity name for vacation day units: %s", self.commodity_vacation_day)
+        self.logger.debug(
+            "Commodity name for worked day units: %s", self.commodity_workday)
+        self.logger.debug("Standard work time period: %s",
+                          str(self.standard_work_period))
         self.logger.debug("Employer: %s", self.employer)
         self.logger.debug("Customer: %s", self.customer)
-        self.logger.debug("Account to use to get working days from: %s", self.account_working_day)
-        self.logger.debug("Account to use to get overtime from: %s", self.account_customer_overtime)
-        self.logger.debug("Account to use to get worked day from: %s", self.account_customer_worked_day)
-        self.logger.debug("Root account of the employer: %s", self.account_employer_root)
-        self.logger.debug("Account to use to store overtime: %s", self.account_employer_overtime)
-        self.logger.debug("Account containing vacation days: %s", self.account_employer_vacation)
-        self.logger.debug("Account to use to store number of worked days: %s", self.account_employer_worked_day)
-        self.logger.debug("Account to use to store number of sickness days: %s", self.account_sickness)
-        self.logger.debug("Account to use to record spent vacation days: %s", self.account_vacation)
-        
+        self.logger.debug(
+            "Account to use to get working days from: %s", self.account_working_day)
+        self.logger.debug("Account to use to get overtime from: %s",
+                          self.account_customer_overtime)
+        self.logger.debug(
+            "Account to use to get worked day from: %s", self.account_customer_worked_day)
+        self.logger.debug("Root account of the employer: %s",
+                          self.account_employer_root)
+        self.logger.debug("Account to use to store overtime: %s",
+                          self.account_employer_overtime)
+        self.logger.debug("Account containing vacation days: %s",
+                          self.account_employer_vacation)
+        self.logger.debug(
+            "Account to use to store number of worked days: %s", self.account_employer_worked_day)
+        self.logger.debug(
+            "Account to use to store number of sickness days: %s", self.account_sickness)
+        self.logger.debug(
+            "Account to use to record spent vacation days: %s", self.account_vacation)
+
         self.logger.info("Object initialisation done.")
-        
+
     def __txn_vacation(self, meta, date, desc, units_vac, units_ovt, price):
         """Return a holiday transaction object."""
         self.logger.debug("Entering Function")
 
-        txn =  data.Transaction(
+        txn = data.Transaction(
             meta, date, "!", self.employer, desc, data.EMPTY_SET, data.EMPTY_SET, [
-                data.Posting(self.account_vacation, units_vac, None, None, None, None),
-                data.Posting(self.account_employer_vacation, -units_vac, None, None, None, None),
-                data.Posting(self.account_vacation, units_vac, None, price, "!", None),
-                data.Posting(self.account_employer_overtime, -units_ovt, None, None, "!", None)
-                ])
+                data.Posting(self.account_vacation, units_vac,
+                             None, None, None, None),
+                data.Posting(self.account_employer_vacation, -
+                             units_vac, None, None, None, None),
+                data.Posting(self.account_vacation, units_vac,
+                             None, price, "!", None),
+                data.Posting(self.account_employer_overtime, -
+                             units_ovt, None, None, "!", None)
+            ])
 
         self.logger.debug('Transaction to be recorded: %s', str(txn))
         self.logger.debug("Leaving Function")
-        
+
         return txn
-        
+
     def __txn_common(self, meta, date, acc_in, acc_out, units_common, payee="", desc=""):
         """Return a transaction object for simple transactions."""
         self.logger.debug("Entering Function")
@@ -162,15 +185,15 @@ class Importer(importer.ImporterProtocol):
         self.logger.debug("Receiving account: %s", acc_in)
         self.logger.debug("Sending account: %s", acc_out)
 
-        txn =  data.Transaction(
+        txn = data.Transaction(
             meta, date, self.FLAG, payee, desc, data.EMPTY_SET, data.EMPTY_SET, [
                 data.Posting(acc_in, units_common, None, None, None, None),
                 data.Posting(acc_out, -units_common, None, None, None, None)
-                ])
+            ])
 
         self.logger.debug('Transaction to be recorded: %s', str(txn))
         self.logger.debug("Leaving Function")
-        
+
         return txn
 
     # def __iof2Amount(self, value, commodity):
@@ -191,18 +214,22 @@ class Importer(importer.ImporterProtocol):
         self.logger.debug("Parameter type: %s", type(time_as_str_or_tuple))
 
         if type(time_as_str_or_tuple) == str:
-            self.logger.debug("Is it in [H]H:MM format: %s", re.fullmatch("^[0-9]{1,2}:[0-5][0-9]$", time_as_str_or_tuple))
+            self.logger.debug("Is it in [H]H:MM format: %s", re.fullmatch(
+                "^[0-9]{1,2}:[0-5][0-9]$", time_as_str_or_tuple))
             if re.fullmatch("^[0-9]{1,2}:[0-5][0-9]$", time_as_str_or_tuple) != None:
-                time_as_tuple = (int(time_as_str_or_tuple.split(':')[0]), int(time_as_str_or_tuple.split(':')[1]))
+                time_as_tuple = (int(time_as_str_or_tuple.split(':')[0]), int(
+                    time_as_str_or_tuple.split(':')[1]))
             else:
-                raise ValueError("Parameter was not a string  of the form [H]H:MM: {}".format(time_as_str_or_tuple))
+                raise ValueError("Parameter was not a string  of the form [H]H:MM: {}".format(
+                    time_as_str_or_tuple))
         elif type(time_as_str_or_tuple) == tuple and len(time_as_str_or_tuple) == 2 and type(time_as_str_or_tuple[0]) == int and type(time_as_str_or_tuple[1]):
             time_as_tuple = time_as_str_or_tuple
         else:
-            raise ValueError("Parameter was not a string or a tuple of 2 elements")
+            raise ValueError(
+                "Parameter was not a string or a tuple of 2 elements")
 
         return (time_as_tuple[0] * 60) + time_as_tuple[1]
-    
+
     def identify(self, file):
         # Match if the filename is as downloaded and the header has the unique
         # fields combination we're looking for.
@@ -214,7 +241,8 @@ class Importer(importer.ImporterProtocol):
         matching_result = self.inputFile.isTimesheetFileName(file.name)
 
         if matching_result:
-            matching_result = re.match("DATE;DAYTYPE;STD;DAYTYPE2;TIMESPENT;DAYTYPE3;TIMEREC;DAYTYPE4;TIMESPENT2", file.head())
+            matching_result = re.match(
+                "DATE;DAYTYPE;STD;DAYTYPE2;TIMESPENT;DAYTYPE3;TIMEREC;DAYTYPE4;TIMESPENT2", file.head())
 
         self.logger.info("Identification result: %s", str(matching_result))
         self.logger.debug("Leaving Function")
@@ -222,7 +250,8 @@ class Importer(importer.ImporterProtocol):
 
     def file_name(self, file):
         self.logger.debug("Entering Function")
-        self.logger.info("File name to be used: %s", 'smals-ts-report.{}'.format(path.basename(file.name)))
+        self.logger.info("File name to be used: %s",
+                         'smals-ts-report.{}'.format(path.basename(file.name)))
         self.logger.debug("Leaving Function")
         return 'smals-ts-report.{}'.format(path.basename(file.name))
 
@@ -256,8 +285,9 @@ class Importer(importer.ImporterProtocol):
         cur_year = 0
         workday_counter = 0
 
-        self.logger.debug('Standard working time period in minutes: %d', self.standard_work_period)
-        
+        self.logger.debug(
+            'Standard working time period in minutes: %d', self.standard_work_period)
+
         for index, row in enumerate(self.inputFile.get_Reader(file.name)):
             self.logger.debug('Data in row: %s', str(row))
             meta = data.new_metadata(file.name, index)
@@ -276,7 +306,8 @@ class Importer(importer.ImporterProtocol):
 
             # If the month or year change, create the transaction for the overtime of the previous month
             if cur_month != month or cur_year != year:
-                meta_w_month['worked_period'] = "{}-{}".format(cur_year, cur_month)
+                meta_w_month['worked_period'] = "{}-{}".format(
+                    cur_year, cur_month)
 
                 cur_month = month
                 cur_year = year
@@ -299,16 +330,17 @@ class Importer(importer.ImporterProtocol):
                                         toAmount(workday_counter,
                                                  self.commodity_workday),
                                         self.customer)
-                self.logger.info('Number of worked day recorded at date: %s', workday_counter)
+                self.logger.info(
+                    'Number of worked day recorded at date: %s', workday_counter)
 
                 entries.append(txn)
                 workday_counter = 0
-                
+
             dtype = row['DAYTYPE']
             dtype2 = row['DAYTYPE2']
             dtype3 = row['DAYTYPE3']
             dtype4 = row['DAYTYPE4']
-            
+
             self.logger.debug('Day of week type: %s', dtype)
             self.logger.debug('Work day type 1: %s', dtype2)
             self.logger.debug('Work day type 2: %s', dtype3)
@@ -331,7 +363,7 @@ class Importer(importer.ImporterProtocol):
                     wk_period = int(wk_period_full / 2)
                 else:
                     wk_period = wk_period_full
-                    
+
                 # Check if a part of the day was a vacation
                 if dtype3 == "CAO":
                     self.logger.info('Half a day was a vacation, record it.')
@@ -342,7 +374,7 @@ class Importer(importer.ImporterProtocol):
                                                        self.commodity_overtime),
                                               toAmount(wk_period_full,
                                                        self.commodity_overtime)
-                    )
+                                              )
                     self.logger.info('Vacation date: %s', date)
                     entries.append(txn)
 
@@ -355,18 +387,20 @@ class Importer(importer.ImporterProtocol):
                                                      self.commodity_workday),
                                             self.employer,
                                             "Incapacité de travail"
-                    )
+                                            )
                     entries.append(txn)
-                    
-                self.logger.info('Worked period for the day (in Minutes): %s', str(wk_period))
+
+                self.logger.info(
+                    'Worked period for the day (in Minutes): %s', str(wk_period))
 
                 overtime = wk_time - wk_period
                 workday_counter += 1
-                
+
                 self.logger.debug('Overtime for the day: %s', str(overtime))
 
                 units_overtime += overtime
-                self.logger.info('Cumulative overtime for the month: %g', units_overtime)
+                self.logger.info(
+                    'Cumulative overtime for the month: %g', units_overtime)
             else:
                 # If it is a work day, but I was sick or it was a legal holiday, skip it.
                 if dtype3 in ["JFR", "COLFE"] and dtype4 == '':
@@ -378,7 +412,7 @@ class Importer(importer.ImporterProtocol):
                         u = 1
                     else:
                         u = 0.5
-                        
+
                     txn = self.__txn_common(meta,
                                             date,
                                             self.account_sickness,
@@ -387,7 +421,7 @@ class Importer(importer.ImporterProtocol):
                                                      self.commodity_workday),
                                             self.employer,
                                             "Incapacité de travail"
-)
+                                            )
                     entries.append(txn)
 
                 # If it is a work day, but I was on vacation, add an entry for a vacation day.
@@ -400,11 +434,11 @@ class Importer(importer.ImporterProtocol):
                                                        self.commodity_overtime),
                                               toAmount(self.standard_work_period,
                                                        self.commodity_overtime)
-                    )
+                                              )
                     self.logger.info('Vacation date: %s', date)
                     entries.append(txn)
                 else:
-                    if  dtype4 == "CAO":
+                    if dtype4 == "CAO":
                         wk_period = int(wk_period / 2)
                         txn = self.__txn_vacation(meta, date, "Demi-jour de congé",
                                                   toAmount(0.5,
@@ -413,16 +447,18 @@ class Importer(importer.ImporterProtocol):
                                                            self.commodity_overtime),
                                                   toAmount(wk_period_full,
                                                            self.commodity_overtime)
-)
+                                                  )
                         self.logger.info('Vacation date: %s', date)
                         entries.append(txn)
                     else:
-                        self.logger.warning("Unknown day type detected, row ignored.")
+                        self.logger.warning(
+                            "Unknown day type detected, row ignored.")
                         self.logger.warning('Data in row: %s', str(row))
                         continue
 
         # When there is no more row to process, create a transaction with the remaining overtime
-        self.logger.debug('End of file reached. Record remaining overtime and number of worked days.')
+        self.logger.debug(
+            'End of file reached. Record remaining overtime and number of worked days.')
         meta_w_month['worked_period'] = "{}-{}".format(cur_year, cur_month)
         txn = self.__txn_common(meta_w_month,
                                 date,
@@ -441,7 +477,8 @@ class Importer(importer.ImporterProtocol):
                                 toAmount(workday_counter,
                                          self.commodity_workday),
                                 self.customer)
-        self.logger.info('Number of worked days recorded at date: %s', workday_counter)
+        self.logger.info(
+            'Number of worked days recorded at date: %s', workday_counter)
         entries.append(txn)
 
         self.logger.debug("Leaving Function")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -6,24 +6,28 @@ from beancount.core import amount
 from enum import Enum, IntEnum, unique, auto
 import decimal
 
+
 class Policy():
     """A Generic policy class."""
     def validate():
         """A validator of the data held by the object."""
         pass
 
+
 @unique
 class VatBelgiumEnum(IntEnum):
     VAT21 = 21
     VAT6 = 6
 
+
 @unique
 class PostingPolicyEnum(Enum):
-    SINGLE = auto() # One posting per account + one posting for VAT
-    MULTI = auto() # Possibly more than one posting per account + one posting for VAT on the total amount
-    SINGLE_INCLUDE_VAT = auto() # One posting per account with VAT included
-    MULTI_NO_VAT = auto() # Possibly more than one posting per account and no posting for VAT
-    SINGLE_NO_VAT = auto() # One posting per account and no posting for VAT
+    SINGLE = auto()  # One posting per account + one posting for VAT
+    MULTI = auto()  # Possibly more than one posting per account + one posting for VAT on the total amount
+    SINGLE_INCLUDE_VAT = auto()  # One posting per account with VAT included
+    MULTI_NO_VAT = auto()  # Possibly more than one posting per account and no posting for VAT
+    SINGLE_NO_VAT = auto()  # One posting per account and no posting for VAT
+
 
 def toAmount(value, commodity):
     """Convert a python built-in value to an Amount object.


### PR DESCRIPTION
The following style changes have been applied:

  - hunt double spaces
  - break lines before 80 characters
  - respect indentation for ending tokens
  - use two lines between classes

Reference: https://www.python.org/dev/peps/pep-0008/